### PR TITLE
Add a new Notebook template for connecting Streams with a bare Kafka broker

### DIFF
--- a/Streams-KafkaParallelSample.ipynb
+++ b/Streams-KafkaParallelSample.ipynb
@@ -78,7 +78,7 @@
     "\n",
     "Other settings, like SSL related settings depend on the broker configuration.\n",
     "\n",
-    "In the Kafka broker, create a partitioned topic, for example three partitions. Enter the bootstrap servers and the topic name into the below cell."
+    "In the Kafka broker, create a partitioned topic, for example with three partitions. Enter the bootstrap servers and the topic name into the below cell."
    ]
   },
   {
@@ -268,7 +268,7 @@
     "\n",
     "\n",
     "# parses the JSON in the message and adds the attributes to a tuple\n",
-    "def flat_message_json(tuple):\n",
+    "def parse_json_to_tuple(tuple):\n",
     "    # the tuple is passed in as dict, the output tuple is typing.NamedTuple\n",
     "    messageAsDict = json.loads(tuple['message']) # {\"sensor_id\": \"sensor_4545\", \"value\": 3567.87, \"ts\": 1559029421}\n",
     "    # 5 required positional arguments: 'sensor_id', 'reading', 'ts', 'partition', and 'messageTimestamp'\n",
@@ -281,14 +281,14 @@
     "    )\n",
     "\n",
     "# map the parallelized stream to the new schema\n",
-    "receivedParallelPartitionedFlattened = receivedParallelPartitioned.map(\n",
-    "    func=flat_message_json,\n",
+    "receivedParallelPartitionedParsed = receivedParallelPartitioned.map(\n",
+    "    func=parse_json_to_tuple,\n",
     "    name='ParseMsgJson',\n",
     "    schema=SensorMessage)\n",
     "\n",
-    "# validate by remove negativ and zero values from the streams,\n",
-    "# pass only positive vaues and timestamps\n",
-    "receivedValidated = receivedParallelPartitionedFlattened.filter(\n",
+    "# validate by removing negative and zero values from the streams,\n",
+    "# pass only positive values and timestamps\n",
+    "receivedValidated = receivedParallelPartitionedParsed.filter(\n",
     "    # remember, the tuple tup is passed as a Python named tuple, not as a dict\n",
     "    lambda tup: (tup.reading > 0) and (tup.ts > 0),\n",
     "    name='Validate')\n",
@@ -304,7 +304,7 @@
     "<a name=\"create_view\"></a>\n",
     "## 2.3 Create a `View` to preview the tuples on the `Stream` \n",
     "\n",
-    "A `View` is a connection to a `Stream` that becomes activated when the application is running. We examine the data from within the notebook in section 4, below.\n"
+    "A `View` is a connection to a `Stream` that becomes activated when the application is running. We examine the data from within the notebook in [section 5](#view), below.\n"
    ]
   },
   {
@@ -325,9 +325,7 @@
     "\n",
     "The `parallelEnd` stream is our final result. We will use `Stream.publish()` to make this stream available to other Streams applications.\n",
     "\n",
-    "If you want to send the stream to another database or system, you would use a sink function (similar to the source function) and invoke it using `Stream.for_each`.\n",
-    "\n",
-    "You can also the functions of other Python packages to send the stream to other systems, for example the eventstore."
+    "If you want to send the stream to another database or system, you would use a sink function and invoke it using `Stream.for_each`. You can also use the functions of other Python packages to send the stream to other systems, for example the eventstore."
    ]
   },
   {
@@ -411,9 +409,7 @@
    "source": [
     "## 3.2 Publish the data to the Kafka topic\n",
     "\n",
-    "For advanced producer configurations please review the [producer configs section](https://kafka.apache.org/21/documentation.html#producerconfigs) of the Kafka documentation. Here we setup only the `bootstrap.servers` as used for the consumers. For a Kafka basic install out of the box this is sufficient. When you have configured authentication or other security options for the consumer, you must configure the same options also for the producer.\n",
-    "\n",
-    "Here we setup only the `bootstrap.servers` as used for the consumers. For a Kafka basic install out of the box this is sufficient."
+    "For advanced producer configurations please review the [producer configs section](https://kafka.apache.org/21/documentation.html#producerconfigs) of the Kafka documentation. Here we setup only the `bootstrap.servers` as used for the consumers. For a Kafka basic install out of the box this is sufficient. When you have configured authentication or other security options for the consumer, you must configure the same options also for the producer.\n"
    ]
   },
   {
@@ -455,7 +451,7 @@
     "consumer_submission_result = submit(ContextTypes.DISTRIBUTED, consumer_topology, cfg)\n",
     "consumer_job = consumer_submission_result.job\n",
     "if consumer_job:\n",
-    "    print(\"JobId of consumer job: \", consumer_job.id , \"\\nJob name: \", consumer_job.name)\n"
+    "    print(\"JobId of consumer job: \", consumer_job.id , \"\\nJob name: \", consumer_job.name)"
    ]
   },
   {

--- a/Streams-KafkaParallelSample.ipynb
+++ b/Streams-KafkaParallelSample.ipynb
@@ -1,0 +1,605 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "# IBM Streams Kafka sample application\n",
+    "\n",
+    "This sample demonstrates how to create a Streams Python application that connects to a Kafka broker by using a consumer group and uses partitioned parallel processing of fetched messages.\n",
+    "\n",
+    "In this notebook, you'll see examples of how to:\n",
+    " 1. [Setup your data connections](#setup)\n",
+    " 1. [Create the consumer application](#create_1)\n",
+    " 1. [Create a simple producer application](#create_2)\n",
+    " 1. [Submit the applications](#launch)\n",
+    " 1. [Connect to the running consumer application to view data](#view)\n",
+    " 1. [Stop the applications](#cancel)\n",
+    "\n",
+    "# Overview\n",
+    "\n",
+    "**About the sample**\n",
+    "\n",
+    "The main goal of the sample is to show how to connect to a Kafka broker and how to create a Kafka consumer group with downstream parallel processing of the fetched messages. A consumer group is mostly used to consume partitioned topics with multiple consumers sharing the partitions. The messages are typically distributed to the partitions by using a *key*. When keyed messages are processed in parallel after reception by a consumer group it is desired to stick a the message keys to one channel only. To achieve this, we route the tuples by a hash of the key to the parallel channel.\n",
+    "\n",
+    "Consuming a single-partition topic with more than one consumers has no advantage as failed consumers are restarted by Streams nearly as quickly as a failover of the single partition to another consumer would take.\n",
+    "\n",
+    "For completion of this sample there is also a data generator that publishes data to the topic.\n",
+    "\n",
+    "**How it works**\n",
+    "\n",
+    "The Python application created in this notebook is submitted to the IBM Streams service for execution. Once the application is running in the service, you can connect to it from the notebook to retrieve the results.\n",
+    "\n",
+    "<img src=\"https://developer.ibm.com/streamsdev/wp-content/uploads/sites/15/2019/04/how-it-works.jpg\" alt=\"How it works\">\n",
+    "\n",
+    "\n",
+    "### Documentation\n",
+    "\n",
+    "- [Kafka consumer groups](https://kafka.apache.org/documentation/#intro_consumers)\n",
+    "- [Streams Python development guide](https://ibmstreams.github.io/streamsx.documentation/docs/latest/python/)\n",
+    "- [Streams Python API](https://streamsxtopology.readthedocs.io/)\n",
+    "- [streamsx.kafka Python package](https://streamsxkafka.readthedocs.io/)\n",
+    "\n",
+    "\n",
+    "\n",
+    "<a name=\"setup\"></a>\n",
+    "# 1. Setup\n",
+    "### 1.1 Add credentials for the IBM Streams service\n",
+    "\n",
+    "With the cell below selected, click the \"Connect to instance\" button in the toolbar to insert the credentials for the service.\n",
+    "\n",
+    "<a target=\"blank\" href=\"https://developer.ibm.com/streamsdev/wp-content/uploads/sites/15/2019/02/connect_icp4d.gif\">See an example</a>."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2 Configure the connection to the Kafka broker\n",
+    "\n",
+    "Kafka consumers and producers are configured by properties. They are described in the Kafka documentation in separate sections for [producers configs](https://kafka.apache.org/21/documentation.html#producerconfigs) and [consumer configs](https://kafka.apache.org/21/documentation.html#consumerconfigs).\n",
+    "\n",
+    "The operators of the underlying SPL toolkit set defaults for some properties. You can review these operator provided defaults in the [toolkit documentation](https://ibmstreams.github.io/streamsx.kafka/doc/spldoc/html/) under **Operators**.\n",
+    "\n",
+    "The most important setting is the `bootstrap.servers` configuration, which is required for botch consumers and producers. This config has the form\n",
+    "```\n",
+    "host1:port1,host2:port2,....\n",
+    "```\n",
+    "Since these servers are just used for the initial connection to discover the full cluster membership (which may change dynamically), this list need not contain the full set of servers (you may want more than one, though, in case a server is down).\n",
+    "\n",
+    "Other settings, like SSL related settings depend on the broker configuration.\n",
+    "\n",
+    "In the Kafka broker, create a partitioned topic, for example three partitions. Enter the bootstrap servers and the topic name into the below cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bootstrap_servers =  # add the bootstrap servers here\n",
+    "topic =  # add the Kafka topic here, it should have multiple partitions\n",
+    "\n",
+    "consumer_configs = dict()\n",
+    "consumer_configs['bootstrap.servers'] = bootstrap_servers\n",
+    "# add more consumer relevant configs if required\n",
+    "# Note: The group.id config is not required here. This is done on Python API level later"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.3 Install or upgrade the `streamsx.kafka` package\n",
+    "\n",
+    "Run the cell below to upgrade to the latest version of the `streamsx.kafka` package or to install the package.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "!{sys.executable} -m pip install --user --upgrade streamsx.kafka\n",
+    "\n",
+    "# When you need to install a specific version of the package, run this line instead:\n",
+    "#!{sys.executable} -m pip install --user streamsx.kafka==somever"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import streamsx.kafka as kafka\n",
+    "import streamsx.topology.context as context\n",
+    "print (\"INFO: streamsx package version: \" + context.__version__)\n",
+    "print (\"INFO: streamsx.kafka package version: \" + kafka.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "<a id=\"create_1\"></a>\n",
+    "# 2. Create the consumer application\n",
+    "\n",
+    "This application subscribes to a Kafka topic by using a consumer group (multiple consumers that share a group identifier).\n",
+    "\n",
+    "We assume that the messages we fetch from the topic, are JSON formatted with the content like\n",
+    "```\n",
+    "{\"sensor_id\": \"sensor_4545\", \"value\": 3567.87, \"ts\": 1559029421}\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All Streams applications start with a Topology object, so start by creating one:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from streamsx.topology.topology import Topology\n",
+    "from streamsx.topology.context import submit, ContextTypes\n",
+    "from streamsx.topology.topology import Routing\n",
+    "from streamsx.topology.schema import StreamSchema\n",
+    "from streamsx.kafka.schema import Schema\n",
+    "\n",
+    "consumer_topology = Topology (name = \"ConsumerGroupSample\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2.1 Create the consumer group\n",
+    "\n",
+    "From the Kafka broker we fetch keyed messages, where the message type is a string. In addition to it we want to fetch the message meta data, like partition number, message timestamp, and other.\n",
+    "\n",
+    "That's why we specify `Schema.StringMessageMeta` as the schema for the created Stream.\n",
+    "\n",
+    "This schema is a structured schema that defines following attributes:\n",
+    "\n",
+    "- message(str) - the message content\n",
+    "- key(str) - the key for partitioning\n",
+    "- topic(str) - the Event Streams topic\n",
+    "- partition(int) - the topic partition number (32 bit)\n",
+    "- offset(int) - the offset of the message within the topic partition (64 bit)\n",
+    "- messageTimestamp(int) - the message timestamp in milliseconds since epoch (64 bit)\n",
+    "\n",
+    "Create the stream `received` by subscribing to the Kafka topic, parallelize the source with `set_parallel` and combine the parallel streams with `end_parallel`. The result is a stream created by a consumer group with three consumers.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "consumerSchema = Schema.StringMessageMeta\n",
+    "received = kafka.subscribe(\n",
+    "    consumer_topology,\n",
+    "    topic=topic,\n",
+    "    schema=consumerSchema,\n",
+    "    group='my_consumer_group', # when not specified it is the job name, concatenated with the topic\n",
+    "    kafka_properties=consumer_configs,\n",
+    "    name=\"SensorSubscribe\"\n",
+    "    ).set_parallel(3).end_parallel()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2.2 Parallelize message processing with schema transform\n",
+    "\n",
+    "Parallelize processing in four parallel channels, routing to the channels is hash based.\n",
+    "We need a consistent hash function that calculates a hash from a string.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "    <b>Warning:</b> The Python <i>hash</i> function cannot be used as a <i>consistent</i> hash function as it adds random salt to the hash calculation. Its result is different after a process restarted. When a processing element in the Streams application is re-launched, the results of <i>hash</i> change, so that the routing to the parallel channel changes.\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# calculate a hash code of a string in a consistent way\n",
+    "# needed for partitioned parallel streams\n",
+    "def string_hashcode(s):\n",
+    "    h = 0\n",
+    "    for c in s:\n",
+    "        h = (31 * h + ord(c)) & 0xFFFFFFFF\n",
+    "    return ((h + 0x80000000) & 0xFFFFFFFF) - 0x80000000\n",
+    "\n",
+    "\n",
+    "# start another parallel region partitioned by message key,\n",
+    "# so that each key always goes into the same parallel channel\n",
+    "receivedParallelPartitioned = received.parallel(\n",
+    "    4,\n",
+    "    routing=Routing.HASH_PARTITIONED,\n",
+    "    func=lambda x: string_hashcode(x['key']))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define a new schema by extending `typing.NamedTuple` and a function that parses the JSON of the messages and maps a couple of attributes of `Schema.StringMessageMeta` to the new schema."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import typing\n",
+    "import json\n",
+    "class SensorMessage(typing.NamedTuple):\n",
+    "    sensor_id: str\n",
+    "    reading: float\n",
+    "    ts: int                # timestamp of the sensor measurement\n",
+    "    partition: int\n",
+    "    messageTimestamp: int  # timestamp of the Kafka message\n",
+    "\n",
+    "\n",
+    "# parses the JSON in the message and adds the attributes to a tuple\n",
+    "def flat_message_json(tuple):\n",
+    "    # the tuple is passed in as dict, the output tuple is typing.NamedTuple\n",
+    "    messageAsDict = json.loads(tuple['message']) # {\"sensor_id\": \"sensor_4545\", \"value\": 3567.87, \"ts\": 1559029421}\n",
+    "    # 5 required positional arguments: 'sensor_id', 'reading', 'ts', 'partition', and 'messageTimestamp'\n",
+    "    return SensorMessage(\n",
+    "        messageAsDict['sensor_id'],\n",
+    "        messageAsDict['value'],\n",
+    "        messageAsDict['ts'],\n",
+    "        tuple['partition'],\n",
+    "        tuple['messageTimestamp']\n",
+    "    )\n",
+    "\n",
+    "# map the parallelized stream to the new schema\n",
+    "receivedParallelPartitionedFlattened = receivedParallelPartitioned.map(\n",
+    "    func=flat_message_json,\n",
+    "    name='ParseMsgJson',\n",
+    "    schema=SensorMessage)\n",
+    "\n",
+    "# validate by remove negativ and zero values from the streams,\n",
+    "# pass only positive vaues and timestamps\n",
+    "receivedValidated = receivedParallelPartitionedFlattened.filter(\n",
+    "    # remember, the tuple tup is passed as a Python named tuple, not as a dict\n",
+    "    lambda tup: (tup.reading > 0) and (tup.ts > 0),\n",
+    "    name='Validate')\n",
+    "\n",
+    "# end parallel processing and (dummy) filter as it is not possible to create a view on a combined stream directly\n",
+    "parallelEnd = receivedValidated.end_parallel().filter(lambda x: x)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a name=\"create_view\"></a>\n",
+    "## 2.3 Create a `View` to preview the tuples on the `Stream` \n",
+    "\n",
+    "A `View` is a connection to a `Stream` that becomes activated when the application is running. We examine the data from within the notebook in section 4, below.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "streamView = parallelEnd.view(name=\"ValidatedSensorData\",\n",
+    "                              description=\"Validated Sensor data\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2.4 Define output\n",
+    "\n",
+    "The `parallelEnd` stream is our final result. We will use `Stream.publish()` to make this stream available to other Streams applications.\n",
+    "\n",
+    "If you want to send the stream to another database or system, you would use a sink function (similar to the source function) and invoke it using `Stream.for_each`.\n",
+    "\n",
+    "You can also the functions of other Python packages to send the stream to other systems, for example the eventstore."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "# publish results as JSON\n",
+    "parallelEnd.publish(topic=\"SensorData\",\n",
+    "                    schema=json,\n",
+    "                    name=\"PublishSensors\")\n",
+    "\n",
+    "# Other options include:\n",
+    "# invoke another sink function:\n",
+    "# parallelEnd.for_each (func=send_to_db)\n",
+    "# parallelEnd.print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"create_2\"></a>\n",
+    "# 3. Create a simple producer application\n",
+    "\n",
+    "To make the consumer application work, we need to publish some data to the topic. Therefore we create another, less complicated application that publishs data to the Kafka broker.\n",
+    "\n",
+    "## 3.1 Define a data generator for the messages and a source stream"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "import time\n",
+    "import json\n",
+    "from datetime import datetime\n",
+    "\n",
+    "\n",
+    "# Define a callable source for data that we push into Event Streams\n",
+    "class SensorReadingsSource(object):\n",
+    "    def __call__(self):\n",
+    "        # This is just an example of using generated data,\n",
+    "        # Here you could connect to db\n",
+    "        # generate data\n",
+    "        # connect to data set\n",
+    "        # open file\n",
+    "        i = 0\n",
+    "        while(i < 500000):\n",
+    "            time.sleep(0.001)\n",
+    "            i = i + 1\n",
+    "            sensor_id = random.randint(1, 100)\n",
+    "            reading = {}\n",
+    "            reading[\"sensor_id\"] = \"sensor_\" + str(sensor_id)\n",
+    "            reading[\"value\"] = random.random() * 3000\n",
+    "            reading[\"ts\"] = int(datetime.now().timestamp())\n",
+    "            yield reading\n",
+    "\n",
+    "producer_topology = Topology(\"SensorProducer\")\n",
+    "\n",
+    "# create the data and map them to the attributes 'message' and 'key' of the\n",
+    "# 'Schema.StringMessage' schema for Kafka, so that we have messages with keys\n",
+    "sensorStream = producer_topology.source(\n",
+    "    SensorReadingsSource(),\n",
+    "    \"RawDataSource\"\n",
+    "    ).map(\n",
+    "        func=lambda reading: {'message': json.dumps(reading),\n",
+    "                              'key': reading['sensor_id']},\n",
+    "        name=\"ToKeyedMessage\",\n",
+    "        schema=Schema.StringMessage)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3.2 Publish the data to the Kafka topic\n",
+    "\n",
+    "For advanced producer configurations please review the [producer configs section](https://kafka.apache.org/21/documentation.html#producerconfigs) of the Kafka documentation. Here we setup only the `bootstrap.servers` as used for the consumers. For a Kafka basic install out of the box this is sufficient. When you have configured authentication or other security options for the consumer, you must configure the same options also for the producer.\n",
+    "\n",
+    "Here we setup only the `bootstrap.servers` as used for the consumers. For a Kafka basic install out of the box this is sufficient."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "producer_configs = dict()\n",
+    "producer_configs['bootstrap.servers'] = bootstrap_servers\n",
+    "# add more producer relevant configs if required\n",
+    "\n",
+    "kafkaSink = kafka.publish(\n",
+    "    sensorStream,\n",
+    "    topic=topic,\n",
+    "    kafka_properties=producer_configs,\n",
+    "    name=\"SensorPublish\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"launch\"></a>\n",
+    "# 4. Submit both applications to the Streaming Analytics Service\n",
+    "A running Streams application is called a *job*. By submitting the topologies we create two independent jobs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Disable SSL certificate verification if necessary\n",
+    "cfg[context.ConfigParams.SSL_VERIFY] = False\n",
+    "\n",
+    "# submit consumer topology as a Streams job\n",
+    "consumer_submission_result = submit(ContextTypes.DISTRIBUTED, consumer_topology, cfg)\n",
+    "consumer_job = consumer_submission_result.job\n",
+    "if consumer_job:\n",
+    "    print(\"JobId of consumer job: \", consumer_job.id , \"\\nJob name: \", consumer_job.name)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# submit producer topology as a Streams job\n",
+    "producer_submission_result = submit(ContextTypes.DISTRIBUTED, producer_topology, cfg)\n",
+    "producer_job = producer_submission_result.job\n",
+    "if producer_job:\n",
+    "    print(\"JobId of producer job: \", producer_job.id , \"\\nJob name: \", producer_job.name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a name=\"view\"></a>\n",
+    "# 5. Use a `View` to access data from the job\n",
+    "Now that the job is started, use the `View` object you created in [step 2.3](#create_view) to start retrieving data from a `Stream`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Connect to the view and display 20 samples of the data\n",
+    "queue = streamView.start_data_fetch()\n",
+    "try:\n",
+    "    for val in range(20):\n",
+    "        print(queue.get())    \n",
+    "finally:\n",
+    "    streamView.stop_data_fetch()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5.1 Display the results in real time\n",
+    "Calling `View.display()` from the notebook displays the results of the view in a table that is updated in real-time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display the results for 60 seconds\n",
+    "streamView.display(duration=60)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## 4.2 See job status \n",
+    "\n",
+    "You can view job status and logs by going to **My Instances** > **Jobs**. Find your job based on the id printed above.\n",
+    "Retrieve job logs using the \"Download jobs\" action from the job's context menu.\n",
+    "\n",
+    "To view other information about the job such as detailed metrics, access the Streams Console.  Go to **My Instances** > **Provisioned Instances**. Select the Streams instance and open the URL listed under *externalConsoleEndpoint* or *serviceConsoleEndpoint*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a name=\"cancel\"></a>\n",
+    "\n",
+    "# 6. Cancel the jobs\n",
+    "\n",
+    "This cell generates widgets you can use to cancel the jobs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cancel the jobs in the IBM Streams service interactively\n",
+    "producer_submission_result.cancel_job_button()\n",
+    "consumer_submission_result.cancel_job_button()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also interact with the job through the [Job](https://streamsxtopology.readthedocs.io/en/stable/streamsx.rest_primitives.html#streamsx.rest_primitives.Job) object returned from `producer_submission_result.job` and `consumer_submission_result.job`\n",
+    "\n",
+    "For example, use `producer_job.cancel()` to cancel the running producer job directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cancel the jobs directly using the Job objects\n",
+    "\n",
+    "# producer_job.cancel()\n",
+    "# consumer_job.cancel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 7. Congratulation\n",
+    "\n",
+    "You created a non-trivial Streams application that connected to a Kafka broker with a consumer group for load sharing. Then you parallelized the processing of the fetched messages in a way that the messages keyes were pinned to the parallel channels. Finally you sampled the processed data by using a view, and published the data within the Streams instance, so that other Streams applications in the instance can subscribe to it.\n",
+    "\n",
+    "Not to forget, to bring the application to life, you also created a simple producer application, which published artificial sensor data to the Kafka topic."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
This template is more than the basic publish-subscribe. It shows:
- How to create a Kafka consumer group with Python topology
- How to use structured schemas
- How to parellelize processing based on a hash