### PR TITLE
Add namespace to the topology

### DIFF
--- a/Streams-BasicSample.ipynb
+++ b/Streams-BasicSample.ipynb
@@ -76,17 +76,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Setup complete, continue to section 1.2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from icpd_core import icpd_util\n",
     "from streamsx.topology import context\n",
@@ -129,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,17 +137,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO: streamsx package version: 1.14.13\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import streamsx.topology.context\n",
     "print(\"INFO: streamsx package version: \" + streamsx.topology.context.__version__)\n",
@@ -174,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,48 +201,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting Topology to Streams for execution..\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9b61720b4f6c47a59339861df309032c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "IntProgress(value=0, bar_style='info', description='Initializing', max=10, style=ProgressStyle(description_wid…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Insecure host connections enabled.\n",
-      "Insecure host connections enabled.\n",
-      "Insecure host connections enabled.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "JobId:  8 \n",
-      "Job name:  natasha::BasicTemplate_8\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# The submission_result object contains information about the running application, or job\n",
     "print(\"Submitting Topology to Streams for execution..\")\n",
@@ -322,7 +267,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.6",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -336,7 +281,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/Streams-BasicSample.ipynb
+++ b/Streams-BasicSample.ipynb
@@ -182,7 +182,7 @@
     "from streamsx.topology.topology import Topology\n",
     "import streamsx.topology.context\n",
     "\n",
-    "topo = Topology(name=\"BasicTemplate\")"
+    "topo = Topology(name=\"BasicTemplate\", namespace=\"sample\")"
    ]
   },
   {

--- a/Streams-CPD-WMLScoringSample.ipynb
+++ b/Streams-CPD-WMLScoringSample.ipynb
@@ -748,7 +748,7 @@
     "from streamsx.topology.topology import Topology\n",
     "import os\n",
     "\n",
-    "topo = Topology(name=\"WMLScoring\")\n",
+    "topo = Topology(name=\"WMLScoring\", namespace=\"sample\")\n",
     "\n",
     "# add files to be contained in the archive which is deployed to the node running the application\n",
     "# in this sample we need the Iris `dataset` with sample data to be present at the worker node\n",

--- a/Streams-DatabaseSample.ipynb
+++ b/Streams-DatabaseSample.ipynb
@@ -212,7 +212,7 @@
     "import streamsx.database as db\n",
     "\n",
     "# create a Topology object\n",
-    "topo = Topology(name=\"DatabaseSample\")"
+    "topo = Topology(name=\"DatabaseSample\", namespace=\"sample\")"
    ]
   },
   {

--- a/Streams-EventStoreSample.ipynb
+++ b/Streams-EventStoreSample.ipynb
@@ -272,7 +272,7 @@
    "source": [
     "from streamsx.topology.topology import Topology\n",
     "\n",
-    "topo = Topology(name=\"EventStoreInsertSample\")"
+    "topo = Topology(name=\"EventStoreInsertSample\", namespace=\"sample\")"
    ]
   },
   {

--- a/Streams-EventStreamsSample.ipynb
+++ b/Streams-EventStreamsSample.ipynb
@@ -178,7 +178,7 @@
    "source": [
     "from streamsx.topology.topology import Topology\n",
     "\n",
-    "topo = Topology(name=\"EventStreamsSample\")"
+    "topo = Topology(name=\"EventStreamsSample\", namespace=\"sample\")"
    ]
   },
   {

--- a/Streams-HbaseSample.ipynb
+++ b/Streams-HbaseSample.ipynb
@@ -141,7 +141,7 @@
     "\n",
     "\n",
     "# create a Topology object\n",
-    "topo = Topology(name=\"hbase\")"
+    "topo = Topology(name=\"hbase\", namespace=\"sample\")"
    ]
   },
   {

--- a/Streams-HdfsSample.ipynb
+++ b/Streams-HdfsSample.ipynb
@@ -182,7 +182,7 @@
     "\n",
     "\n",
     "# create a Topology object\n",
-    "topo = Topology(name=\"hdfs\")"
+    "topo = Topology(name=\"hdfs\", namespace=\"sample\")"
    ]
   },
   {

--- a/Streams-KafkaBasicSample.ipynb
+++ b/Streams-KafkaBasicSample.ipynb
@@ -177,7 +177,7 @@
     "from streamsx.kafka.schema import Schema\n",
     "from streamsx.kafka import AuthMethod\n",
     "\n",
-    "consumer_topology = Topology(name='KafkaBasicSample-Consumer')"
+    "consumer_topology = Topology(name='KafkaBasicSample-Consumer', namespace='sample')"
    ]
   },
   {
@@ -375,7 +375,7 @@
     "            reading[\"ts\"] = int(datetime.now().timestamp())\n",
     "            yield reading\n",
     "\n",
-    "producer_topology = Topology(name='KafkaBasicSample-Producer')\n",
+    "producer_topology = Topology(name='KafkaBasicSample-Producer', namespace='sample')\n",
     "\n",
     "# create the data and map them to the attributes 'message' and 'key' of the\n",
     "# 'Schema.StringMessage' schema for Kafka, so that we have messages with keys\n",

--- a/Streams-KafkaParallelSample.ipynb
+++ b/Streams-KafkaParallelSample.ipynb
@@ -177,7 +177,7 @@
     "from streamsx.kafka.schema import Schema\n",
     "from streamsx.kafka import AuthMethod\n",
     "\n",
-    "consumer_topology = Topology(name='KafkaParallelSample-Consumer')"
+    "consumer_topology = Topology(name='KafkaParallelSample-Consumer', namespace='sample')"
    ]
   },
   {
@@ -474,7 +474,7 @@
     "            reading[\"ts\"] = int(datetime.now().timestamp())\n",
     "            yield reading\n",
     "\n",
-    "producer_topology = Topology(name='KafkaParallelSample-Producer')\n",
+    "producer_topology = Topology(name='KafkaParallelSample-Producer', namespace='sample')\n",
     "\n",
     "# create the data and map them to the attributes 'message' and 'key' of the\n",
     "# 'Schema.StringMessage' schema for Kafka, so that we have messages with keys\n",

--- a/Streams-PMMLScoringSample.ipynb
+++ b/Streams-PMMLScoringSample.ipynb
@@ -198,7 +198,7 @@
     "from streamsx.topology.topology import Topology\n",
     "import os\n",
     "\n",
-    "topo = Topology(name=\"PMMLScoring\")\n",
+    "topo = Topology(name=\"PMMLScoring\", namespace=\"sample\")\n",
     "\n",
     "# add files to be contained in the archive which is deployed to the node running the application\n",
     "# in this sample we need the `dataset` with sample data to be present at the worker node\n",

--- a/Streams-RollingAverageSample.ipynb
+++ b/Streams-RollingAverageSample.ipynb
@@ -191,7 +191,7 @@
    "source": [
     "from streamsx.topology.topology import Topology\n",
     "\n",
-    "topo = Topology(name=\"SensorAverages\")"
+    "topo = Topology(name=\"SensorAverages\", namespace=\"sample\")"
    ]
   },
   {

--- a/Streams-SPLToolkitsTutorial.ipynb
+++ b/Streams-SPLToolkitsTutorial.ipynb
@@ -507,7 +507,7 @@
     "        for i in range(self.count):\n",
     "            yield doc + ' - doc_' + str(i)\n",
     "\n",
-    "topo = Topology(\"NLPSample\")\n",
+    "topo = Topology(\"NLPSample\", namespace=\"sample\")\n",
     "s = topo.source(StringData(1000)).as_string()\n",
     "s.publish(\"streamsx/nlp/documents\", schema=CommonSchema.String)\n",
     "    \n",
@@ -622,7 +622,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "topo_spl = Topology(\"WrapSPLOperatorsSample\")"
+    "topo_spl = Topology(\"WrapSPLOperatorsSample\", namespace=\"sample\")"
    ]
   },
   {


### PR DESCRIPTION
When the Topology object is created w/o namespace, streamsx creates a namespace from the project. When the project name is a reserved word in SPL,  for example **stream**, the generated SPL code won't compile. As a workaround for this potential complication, I added the namespace "sample" to all notebooks:
```
topo = Topology(name="whatever", namespace="sample")
```
The Streams-BasicSample notebook contained the output of a previous run. This has been cleaned up now.